### PR TITLE
Correct headers for the different IC images

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,12 +39,12 @@
 <p></p>
 
 <hr size="1">
-<h3>PFS154-S14</h3>
+<h3>PFS154-S16/D16</h3>
 <img src="images/PFS154_S16_D16.png"/>
 <p></p>
 
 <hr size="1">
-<h3>PFS154-S14</h3>
+<h3>PMS154C-S16/D16</h3>
 <img src="images/PMS154C_S16_D16.png"/>
 <p></p>
 


### PR DESCRIPTION
This corrects a copy & paste error in the headers above each of the different IC images in the Overview.