### PR TITLE
Add ROM/RAM sizes and link to instruction set documentation

### DIFF
--- a/_layouts/chip.html
+++ b/_layouts/chip.html
@@ -10,10 +10,12 @@ layout: default
 
   <div class="post-content">
     <ul>
-      <li><strong>Instruction Set</strong>: {{ page.instruction_set }} bit</li>
-      <li><strong>Official Product Page</strong>: <a href="{{ page.product_page }}">{{ page.product_page }}</a></li>
-      <li><strong>Supported by Easy PDK Programmer</strong>: {% if page.easypdk_supported %}yes{% else %}no{% endif %}</li>
+      <li><strong>Instruction Set</strong>: <a href="/PADAUK_FPPA_{{ page.instruction_set }}_bit_instruction_set.html">{{ page.instruction_set }} bit</a></li>
+      <li><strong>ROM Size</strong>: {{ page.rom_size }}</li>
+      <li><strong>RAM Size</strong>: {{ page.ram_size }} bytes</li>
       <li><strong>Programming Mode</strong>: {{ page.programming | upcase }}</li>
+      <li><strong>Supported by Easy PDK Programmer</strong>: {% if page.easypdk_supported %}yes{% else %}no{% endif %}</li>
+      <li><strong>Official Product Page</strong>: <a href="{{ page.product_page }}">{{ page.product_page }}</a></li>
     </ul>
 
 

--- a/chips/PFS154.md
+++ b/chips/PFS154.md
@@ -1,6 +1,8 @@
 ---
 layout: chip
 instruction_set: 14
+rom_size: 2KW
+ram_size: 128
 product_page: http://www.padauk.com.tw/en/product/show.aspx?num=66&kind=42
 easypdk_supported: true
 has_pinout_diagram: true

--- a/chips/PFS172.md
+++ b/chips/PFS172.md
@@ -1,6 +1,8 @@
 ---
 layout: chip
 instruction_set: 14
+rom_size: 2KW
+ram_size: 128
 product_page: http://www.padauk.com.tw/en/product/show.aspx?num=108&kind=42
 easypdk_supported: true
 has_pinout_diagram: true

--- a/chips/PFS173.md
+++ b/chips/PFS173.md
@@ -1,6 +1,8 @@
 ---
 layout: chip
 instruction_set: 15
+rom_size: 3KW
+ram_size: 256
 product_page: http://www.padauk.com.tw/en/product/show.aspx?num=90&kind=42
 easypdk_supported: true
 has_pinout_diagram: true

--- a/chips/PMS154C.md
+++ b/chips/PMS154C.md
@@ -1,6 +1,8 @@
 ---
 layout: chip
 instruction_set: 14
+rom_size: 2KW
+ram_size: 128
 product_page: http://www.padauk.com.tw/en/product/show.aspx?num=66&kind=42
 easypdk_supported: true
 programming: otp

--- a/index.md
+++ b/index.md
@@ -54,13 +54,14 @@ outdated and may not have support or only limited support for the Padauk µCs.
 ## µC-specific Information and Pinouts
 
 Note: Other µCs than the µCs listed here are supported.
-It is an ongoing effor to create pinout diagrams for all supported Padauk µCs.
+It is an ongoing effort to create pinout diagrams for all supported Padauk µCs.
 
 {% for page in site.pages -%}
 {%- if page.layout == "chip" -%}
 - **[{{ page.title }}]({{ page.url }})**
   <span class="badge">{{ page.instruction_set }} bit instruction set</span>
-  <span class="badge">{{ page.programming | upcase }}</span>
+  <span class="badge">{{ page.rom_size }} {{ page.programming | upcase }}</span>
+  <span class="badge">{{ page.ram_size }} bytes RAM</span>
 {% endif -%}
 {%- endfor %}
 


### PR DESCRIPTION
We might still want to add in other information and badges like "8-bit ADC", "12-bit ADC", "3x 11-bit PWM", "8x8 multiplier", etc...