### PR TITLE
Use new pinout diagram SDK

### DIFF
--- a/_layouts/chip.html
+++ b/_layouts/chip.html
@@ -27,17 +27,13 @@ layout: default
 {% if page.has_pinout_diagram %}
 </div> <!-- Close wrapper div of parent layout -->
 
-<div class="pinout-diagram">
-  <iframe id="pinout-diagram" frameborder="0" allowtransparency="true"
-    src="https://christianflach.de/ic-pinout-diagram-generator?ic={{ page.title | url_encode }}&embed=1">
-  </iframe>
-</div>
-<script
-  src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.11/iframeResizer.min.js"
-  integrity="sha512-HY1lApSG7xxx8mYzs/lxRs+c5AaDThRaa3pvQB6puiswvf2lWqMJVf+8qSGiL4ZXfHQoPIqbd1TlpqfycPo3cQ=="
-  crossorigin="anonymous"></script>
+<div id="pinout-diagram"></div>
+<script src="https://unpkg.com/@cmfcmf/pinout-diagrams/dist/sdk.min.js"></script>
 <script>
-  iFrameResize({ sizeHeight: true, sizeWidth: false, scrolling: 'omit' }, '#pinout-diagram');
+  PinoutDiagrams.render(document.getElementById('pinout-diagram'), {
+    ics: ["{{ page.title }}"],
+    maxWidth: '980px'
+  });
 </script>
 <div class="wrapper"> <!-- Reopen wrapper div of parent layout -->
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -13,11 +13,11 @@ $content-width: 1040px;
   font-size: 0.85em;
 }
 
-.pinout-diagram {
-  margin: 2em 0;
+#pinout-diagram {
+  margin: 0 $spacing-unit;
 
-  iframe {
-    width: 100%;
+  @include media-query($on-laptop) {
+    margin: 0 $spacing-unit / 2;
   }
 }
 td {


### PR DESCRIPTION
I reworked how the pinout diagrams work and created an "SDK" that no longer requires the weird iframe. I also updated the styling once again and removed the "download image" buttons (I simply couldn't get them to work consistently, fixes #15).

![image](https://user-images.githubusercontent.com/2145092/87019625-1f8fcf00-c1d3-11ea-8ff0-7c2f2504b57f.png)

~~Edit: I have just fixed a typo and published a new version - it might take up to 15 minutes until the new version is live at unpkg.com. Before that, you might get this error in the browser console: "Uncaught ReferenceError: PinoutDiagrams is not defined"~~