### PR TITLE
Use exclusion list to exclude irrelevant projects

### DIFF
--- a/_plugins/find_github_projects_using_padauk.rb
+++ b/_plugins/find_github_projects_using_padauk.rb
@@ -5,7 +5,12 @@ module GitHubPadaukTopics
   class Generator < Jekyll::Generator
     safe true
 
-    QUERY = 'topic:padauk -language:shell archived:false sort:updated'  # -user:free-pdk 
+    # Exclude projects that use the padauk tag but are not actually about Padauk microcontrollers
+    excluded_projects = [
+      'kaiz16/zg-xkb',
+    ]
+
+    QUERY = 'topic:padauk archived:false sort:updated ' + excluded_projects.map { |name| "-repo:#{name}" }.join(" ")
 
     def cache
       @@cache ||= Jekyll::Cache.new("GitHubPadaukTopics")


### PR DESCRIPTION
Having thought about this a bit more, I think we should go ahead with @cpldcpu's suggestion: 
- keep using the `padauk` tag
- maintain an exclusion list