### PR TITLE
Add section on code options

### DIFF
--- a/_includes/device_code_options.html
+++ b/_includes/device_code_options.html
@@ -1,3 +1,5 @@
+Click on an individual table cell to get the code that controls the corresponding code option.
+
 <div class="table-responsive">
   <table class="device-code-options">
     <thead>
@@ -46,55 +48,55 @@
               {% assign o = chip.code_options %}
 
               {% comment %} Fuses {% endcomment %}
-              <td title="{{ o.fuse.security | join:', ' | default: 'FUSE_SECURITY_ON, FUSE_SECURITY_OFF' }}">
+              <td data-type="fuse" title="{{ o.fuse.security | join:', ' | default: 'FUSE_SECURITY_ON, FUSE_SECURITY_OFF' }}">
                 {% if o.fuse contains 'security' %}x{% endif %}
               </td>
-              <td title="{{ o.fuse.pin_drive | join:', ' }}">
+              <td data-type="fuse" title="{{ o.fuse.pin_drive | join:', ' }}">
                 {% if o.fuse contains 'pin_drive' %}x{% endif %}
               </td>
-              <td title="{{ o.fuse.bootup | join:', ' | default: 'FUSE_BOOTUP_SLOW, FUSE_BOOTUP_FAST' }}">
+              <td data-type="fuse" title="{{ o.fuse.bootup | join:', ' | default: 'FUSE_BOOTUP_SLOW, FUSE_BOOTUP_FAST' }}">
                 {% if o.fuse contains 'bootup' %}x{% endif %}
               </td>
-              <td title="{{ o.fuse.lvr | join:', ' | default: 'FUSE_LVR_4V, FUSE_LVR_3V5, FUSE_LVR_3V, FUSE_LVR_2V75, FUSE_LVR_2V5, FUSE_LVR_1V8, FUSE_LVR_2V2, FUSE_LVR_2V' }}">
+              <td data-type="fuse" title="{{ o.fuse.lvr | join:', ' | default: 'FUSE_LVR_4V, FUSE_LVR_3V5, FUSE_LVR_3V, FUSE_LVR_2V75, FUSE_LVR_2V5, FUSE_LVR_1V8, FUSE_LVR_2V2, FUSE_LVR_2V' }}">
                 {% if o.fuse contains 'lvr' %}x{% endif %}
               </td>
 
               {% comment %} ROP {% endcomment %}
-              <td title="ROP_INT_SRC_PA0, ROP_INT_SRC_PB5">
+              <td data-type="ROP" title="ROP_INT_SRC_PA0, ROP_INT_SRC_PB5">
                 {% if o.rom contains 'int0' %}x{% endif %}
               </td>
-              <td title="ROP_INT_SRC_PB0, ROP_INT_SRC_PA4">
+              <td data-type="ROP" title="ROP_INT_SRC_PB0, ROP_INT_SRC_PA4">
                 {% if o.rom contains 'int1' %}x{% endif %}
               </td>
-              <td title="ROP_TMX_6BIT, ROP_TMX_7BIT">
+              <td data-type="ROP" title="ROP_TMX_6BIT, ROP_TMX_7BIT">
                 {% if o.rom contains 'tmx_bits' %}x{% endif %}
               </td>
-              <td title="ROP_TMX_16MHZ, ROP_TMX_32MHZ">
+              <td data-type="ROP" title="ROP_TMX_16MHZ, ROP_TMX_32MHZ">
                 {% if o.rom contains 'tmx_freq' %}x{% endif %}
               </td>
-              <td title="ROP_PURE_PWM, ROP_GPC_PWM">
+              <td data-type="ROP" title="ROP_PURE_PWM, ROP_GPC_PWM">
                 {% if o.rom contains 'pwm_sel' %}x{% endif %}
               </td>
-              <td title="ROP_PWM_16MHZ, ROP_PWM_32MHZ">
+              <td data-type="ROP" title="ROP_PWM_16MHZ, ROP_PWM_32MHZ">
                 {% if o.rom contains 'pwm_freq' %}x{% endif %}
               </td>
-              <td title="ROP_TM2_PB2, ROP_TM2_PB0">
+              <td data-type="ROP" title="ROP_TM2_PB2, ROP_TM2_PB0">
                 {% if o.rom contains 'tm2_out' %}x{% endif %}
               </td>
 
               {% comment %} MISC2 {% endcomment %}
-              <td title="MISC2_COMP_EDGE_INT_BOTH, MISC2_COMP_EDGE_INT_RISE, MISC2_COMP_EDGE_INT_FALL">
+              <td data-type="MISC2" title="MISC2_COMP_EDGE_INT_BOTH, MISC2_COMP_EDGE_INT_RISE, MISC2_COMP_EDGE_INT_FALL">
                 {% if o.misc2 contains 'comp_edge' %}x{% endif %}
               </td>
 
               {% comment %} MISCLVR {% endcomment %}
-              <td title="MISCLVR_4V, MISCLVR_3V5, MISCLVR_3V, MISCLVR_2V75, MISCLVR_2V5, MISCLVR_1V8, MISCLVR_2V2, MISCLVR_2V">
+              <td data-type="MISCLVR" title="MISCLVR_4V, MISCLVR_3V5, MISCLVR_3V, MISCLVR_2V75, MISCLVR_2V5, MISCLVR_1V8, MISCLVR_2V2, MISCLVR_2V">
                 {% if o.misclvr contains 'lvr_3bit' %}x{% endif %}
               </td>
-              <td title="MISCLVR_1V8, MISCLVR_1V9, MISCLVR_2V, MISCLVR_2V1, MISCLVR_2V2, MISCLVR_2V3, MISCLVR_2V4, MISCLVR_2V5, MISCLVR_2V7, MISCLVR_3V, MISCLVR_3V15, MISCLVR_3V3, MISCLVR_3V5, MISCLVR_3V75, MISCLVR_4V, MISCLVR_4V5">
+              <td data-type="MISCLVR" title="MISCLVR_1V8, MISCLVR_1V9, MISCLVR_2V, MISCLVR_2V1, MISCLVR_2V2, MISCLVR_2V3, MISCLVR_2V4, MISCLVR_2V5, MISCLVR_2V7, MISCLVR_3V, MISCLVR_3V15, MISCLVR_3V3, MISCLVR_3V5, MISCLVR_3V75, MISCLVR_4V, MISCLVR_4V5">
                 {% if o.misclvr contains 'lvr_4bit' %}x{% endif %}
               </td>
-              <td title="MISCLVR_BANDGAP_ON, MISCLVR_BANDGAP_DIV4, MISCLVR_BANDGAP_DIV32, MISCLVR_BANDGAP_AUTO">
+              <td data-type="MISCLVR" title="MISCLVR_BANDGAP_ON, MISCLVR_BANDGAP_DIV4, MISCLVR_BANDGAP_DIV32, MISCLVR_BANDGAP_AUTO">
                 {% if o.misclvr contains 'bandgap' %}x{% endif %}
               </td>
             {% else %}
@@ -128,23 +130,35 @@
 />
 <script>
   // Step 1:
-  // Rename all title attributes to data-tippy-content if the cell contains an 'x'
-  // and remove the title attribute.
-  // This is done so that browsers without JavaScript still have see a title on hover,
+  // If the cell contains 'x',
+  // - set data-tippy-content based on title and type (fuse, ROP, MISC, MISCLVR)
+  // - remove the title attribute
+  // - add the 'hoverable' class for better styling
+  //
+  // This is done so that browsers without JavaScript still see a title on hover,
   // but browsers with JavaScript do not display two titles (the tippy title and the native title).
   document.querySelectorAll('.device-code-options td[title]').forEach(element => {
     const title = element.getAttribute('title');
     if (element.textContent.trim() === "x") {
-      element.setAttribute('data-tippy-content', title);
+      element.setAttribute('data-tippy-content', title
+        .split(", ")
+        .map(define => element.dataset.type === 'fuse'
+          ? `PDK_SET_FUSE(${define});`
+          : `${element.dataset.type} = ${define};`)
+        .join("<br>")
+      );
+      element.className += ' hoverable';
     }
     element.removeAttribute('title');
   });
   // Step 2:
-  // Enable fancy titles
+  // Enable fancy titles on click.
   tippy(".device-code-options td[data-tippy-content]", {
-    interactive: true,
-    delay: [100, 0],
+    interactive: true,     // text is copyable
     theme: 'light-border',
     placement: 'bottom',
+    allowHTML: true,       // we use <br> to display one option per line
+    trigger: 'click',      // only trigger the tooltip on click
+    hideOnClick: true,     // and dismiss the tooltip when clicking elsewhere
   });
 </script>

--- a/_includes/device_code_options.html
+++ b/_includes/device_code_options.html
@@ -1,6 +1,6 @@
 <div class="table-responsive">
-  <table>
-    <thead style="font-size: 14px">
+  <table class="device-code-options">
+    <thead>
       <tr>
         <th colspan="1" rowspan="3">µC</th>
         <th colspan="4" rowspan="2">Fuse</th>
@@ -13,7 +13,7 @@
       </tr>
       <tr>
         <th>Security</th>
-        <th>Drive Pins</th>
+        <th>Pin Drive</th>
         <th>Startup Speed</th>
         <th>3-bit LVR</th>
 
@@ -115,3 +115,36 @@
   {% endif %}
 {% endfor %}
 {% endfor %}
+
+{% comment %}
+  JS for better tooltips whose text is copyable/selectable.
+  https://atomiks.github.io/tippyjs/v6/getting-started/
+{% endcomment %}
+<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://unpkg.com/tippy.js@6"></script>
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/tippy.js@6/themes/light-border.css"
+/>
+<script>
+  // Step 1:
+  // Rename all title attributes to data-tippy-content if the cell contains an 'x'
+  // and remove the title attribute.
+  // This is done so that browsers without JavaScript still have see a title on hover,
+  // but browsers with JavaScript do not display two titles (the tippy title and the native title).
+  document.querySelectorAll('.device-code-options td[title]').forEach(element => {
+    const title = element.getAttribute('title');
+    if (element.textContent.trim() === "x") {
+      element.setAttribute('data-tippy-content', title);
+    }
+    element.removeAttribute('title');
+  });
+  // Step 2:
+  // Enable fancy titles
+  tippy(".device-code-options td[data-tippy-content]", {
+    interactive: true,
+    delay: [100, 0],
+    theme: 'light-border',
+    placement: 'bottom',
+  });
+</script>

--- a/_includes/device_code_options.html
+++ b/_includes/device_code_options.html
@@ -8,12 +8,12 @@ Click on an individual table cell to get the code that controls the correspondin
         <th colspan="4" rowspan="2">Fuse</th>
         <th colspan="12">Undocumented Register</th>
       </tr>
-      <tr>
+      <tr class="smaller">
         <th colspan="7">ROP</th>
         <th colspan="1">MISC2</th>
         <th colspan="3">MISCLVR</th>
       </tr>
-      <tr>
+      <tr class="smaller">
         <th>Security</th>
         <th>Pin Drive</th>
         <th>Startup Speed</th>

--- a/_includes/device_code_options.html
+++ b/_includes/device_code_options.html
@@ -1,0 +1,117 @@
+<div class="table-responsive">
+  <table>
+    <thead style="font-size: 14px">
+      <tr>
+        <th colspan="1" rowspan="3">µC</th>
+        <th colspan="4" rowspan="2">Fuse</th>
+        <th colspan="12">Undocumented Register</th>
+      </tr>
+      <tr>
+        <th colspan="7">ROP</th>
+        <th colspan="1">MISC2</th>
+        <th colspan="3">MISCLVR</th>
+      </tr>
+      <tr>
+        <th>Security</th>
+        <th>Drive Pins</th>
+        <th>Startup Speed</th>
+        <th>3-bit LVR</th>
+
+        <th>INT0 Source</th>
+        <th>INT1 Source</th>
+        <th>TMX Bits</th>
+        <th>TMX CLK</th>
+        <th>PWM Type</th>
+        <th>PWM CLK</th>
+        <th>TM2 OUT</th>
+
+        <th>COMP INT Edge</th>
+
+        <th>3-bit LVR</th>
+        <th>4-bit LVR</th>
+        <th>Bandgap CLK</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% assign groups = site.pages
+          | where_exp:"page","page.layout == 'chip'"
+          | group_by_exp:"chip","chip.related_to | default: chip.title" %}
+      {% for group in groups %}
+        {% for chip in group.items -%}
+          <tr>
+            <td markdown="span">
+              **[{{ chip.title }}]({{ chip.url }}){% if chip.code_options.notes %}[^code-option-note-{{ chip.title }}]{% endif %}**
+            </td>
+            {% if chip.code_options %}
+              {% assign o = chip.code_options %}
+
+              {% comment %} Fuses {% endcomment %}
+              <td title="{{ o.fuse.security | join:', ' | default: 'FUSE_SECURITY_ON, FUSE_SECURITY_OFF' }}">
+                {% if o.fuse contains 'security' %}x{% endif %}
+              </td>
+              <td title="{{ o.fuse.pin_drive | join:', ' }}">
+                {% if o.fuse contains 'pin_drive' %}x{% endif %}
+              </td>
+              <td title="{{ o.fuse.bootup | join:', ' | default: 'FUSE_BOOTUP_SLOW, FUSE_BOOTUP_FAST' }}">
+                {% if o.fuse contains 'bootup' %}x{% endif %}
+              </td>
+              <td title="{{ o.fuse.lvr | join:', ' | default: 'FUSE_LVR_4V, FUSE_LVR_3V5, FUSE_LVR_3V, FUSE_LVR_2V75, FUSE_LVR_2V5, FUSE_LVR_1V8, FUSE_LVR_2V2, FUSE_LVR_2V' }}">
+                {% if o.fuse contains 'lvr' %}x{% endif %}
+              </td>
+
+              {% comment %} ROP {% endcomment %}
+              <td title="ROP_INT_SRC_PA0, ROP_INT_SRC_PB5">
+                {% if o.rom contains 'int0' %}x{% endif %}
+              </td>
+              <td title="ROP_INT_SRC_PB0, ROP_INT_SRC_PA4">
+                {% if o.rom contains 'int1' %}x{% endif %}
+              </td>
+              <td title="ROP_TMX_6BIT, ROP_TMX_7BIT">
+                {% if o.rom contains 'tmx_bits' %}x{% endif %}
+              </td>
+              <td title="ROP_TMX_16MHZ, ROP_TMX_32MHZ">
+                {% if o.rom contains 'tmx_freq' %}x{% endif %}
+              </td>
+              <td title="ROP_PURE_PWM, ROP_GPC_PWM">
+                {% if o.rom contains 'pwm_sel' %}x{% endif %}
+              </td>
+              <td title="ROP_PWM_16MHZ, ROP_PWM_32MHZ">
+                {% if o.rom contains 'pwm_freq' %}x{% endif %}
+              </td>
+              <td title="ROP_TM2_PB2, ROP_TM2_PB0">
+                {% if o.rom contains 'tm2_out' %}x{% endif %}
+              </td>
+
+              {% comment %} MISC2 {% endcomment %}
+              <td title="MISC2_COMP_EDGE_INT_BOTH, MISC2_COMP_EDGE_INT_RISE, MISC2_COMP_EDGE_INT_FALL">
+                {% if o.misc2 contains 'comp_edge' %}x{% endif %}
+              </td>
+
+              {% comment %} MISCLVR {% endcomment %}
+              <td title="MISCLVR_4V, MISCLVR_3V5, MISCLVR_3V, MISCLVR_2V75, MISCLVR_2V5, MISCLVR_1V8, MISCLVR_2V2, MISCLVR_2V">
+                {% if o.misclvr contains 'lvr_3bit' %}x{% endif %}
+              </td>
+              <td title="MISCLVR_1V8, MISCLVR_1V9, MISCLVR_2V, MISCLVR_2V1, MISCLVR_2V2, MISCLVR_2V3, MISCLVR_2V4, MISCLVR_2V5, MISCLVR_2V7, MISCLVR_3V, MISCLVR_3V15, MISCLVR_3V3, MISCLVR_3V5, MISCLVR_3V75, MISCLVR_4V, MISCLVR_4V5">
+                {% if o.misclvr contains 'lvr_4bit' %}x{% endif %}
+              </td>
+              <td title="MISCLVR_BANDGAP_ON, MISCLVR_BANDGAP_DIV4, MISCLVR_BANDGAP_DIV32, MISCLVR_BANDGAP_AUTO">
+                {% if o.misclvr contains 'bandgap' %}x{% endif %}
+              </td>
+            {% else %}
+              <td colspan="15"><em>No code option data available yet.</em></td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{% for group in groups %}
+{% for chip in group.items -%}
+  {% if chip.code_options.notes %}
+[^code-option-note-{{ chip.title }}]:
+    {{ chip.code_options.notes }}
+  {% endif %}
+{% endfor %}
+{% endfor %}

--- a/_includes/device_code_options.html
+++ b/_includes/device_code_options.html
@@ -8,7 +8,7 @@ Click on an individual table cell to get the code that controls the correspondin
         <th colspan="4" rowspan="2">Fuse</th>
         <th colspan="12">Undocumented Register</th>
       </tr>
-      <tr class="smaller">
+      <tr>
         <th colspan="7">ROP</th>
         <th colspan="1">MISC2</th>
         <th colspan="3">MISCLVR</th>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -189,6 +189,11 @@ td.callout {
   thead {
     font-size: 14px;
   }
+
+  td.hoverable:hover {
+    background-color: $grey-color-light;
+    cursor: pointer;
+  }
 }
 
 // Used when using kramdown footnotes

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -185,6 +185,12 @@ td.callout {
   text-align: left;
 }
 
+.device-code-options {
+  thead {
+    font-size: 14px;
+  }
+}
+
 // Used when using kramdown footnotes
 .footnotes {
   padding-top: $spacing-unit / 2;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -187,7 +187,7 @@ td.callout {
 
 .device-code-options {
   thead {
-    font-size: 14px;
+    font-size: 13px;
   }
 
   td.hoverable:hover {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -205,7 +205,9 @@ td.callout {
 
 .device-code-options {
   thead {
-    font-size: 13px;
+    .smaller {
+      font-size: 13px;
+    }
   }
 
   td.hoverable:hover {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -184,3 +184,10 @@ td.callout {
   font-size: smaller;
   text-align: left;
 }
+
+// Used when using kramdown footnotes
+.footnotes {
+  padding-top: $spacing-unit / 2;
+  border-top: $border;
+  font-size: 13px;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -195,10 +195,3 @@ td.callout {
     cursor: pointer;
   }
 }
-
-// Used when using kramdown footnotes
-.footnotes {
-  padding-top: $spacing-unit / 2;
-  border-top: $border;
-  font-size: 13px;
-}

--- a/chips/PFS154.md
+++ b/chips/PFS154.md
@@ -14,6 +14,15 @@ Comp: 1
 ADC: "-"
 Special: LCD
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_IO_DRV_LOW, FUSE_IO_DRV_NORMAL]
+    bootup:
+  misc2:
+    comp_edge:
+  misclvr:
+    lvr_3bit:
 ---
 
 # PFS154

--- a/chips/PFS172.md
+++ b/chips/PFS172.md
@@ -12,8 +12,26 @@ timers: T16,T2 T3
 PWM: 2x 8-Bit
 Comp: 1
 ADC: 8-Bit
-Special: 
+Special:
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_PB4_PB7_NORMAL, FUSE_PB4_PB7_STRONG]
+    bootup:
+  rom:
+    int0:
+    int1:
+    tmx_bits:
+    tmx_freq:
+    pwm_sel:
+  misc2:
+    comp_edge:
+  misclvr:
+    lvr_4bit:
+    bandgap:
+  notes: |
+    Some additional options seem to exist which are not documented in the datasheet: <https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs172.h#L153-L165>
 ---
 
 # PFS172

--- a/chips/PFS173.md
+++ b/chips/PFS173.md
@@ -14,6 +14,23 @@ Comp: 1
 ADC: 8-Bit
 Special: LCD
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_PB4_PB5_NORMAL, FUSE_PB4_PB5_STRONG]
+    bootup:
+  rom:
+    int0:
+    int1:
+    tmx_bits:
+    tmx_freq:
+    pwm_sel:
+    pwm_freq:
+  misc2:
+    comp_edge:
+  misclvr:
+    lvr_4bit:
+    bandgap:
 ---
 
 # PFS173

--- a/chips/PMS150C.md
+++ b/chips/PMS150C.md
@@ -14,6 +14,12 @@ Comp: 1
 ADC: "-"
 Special: "-"
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_IO_DRV_LOW, FUSE_IO_DRV_NORMAL]
+    bootup:
+    lvr:
 ---
 
 # PMS150C

--- a/chips/PMS152.md
+++ b/chips/PMS152.md
@@ -14,6 +14,22 @@ Comp: 1
 ADC: "-"
 Special: "-"
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    bootup:
+  rom:
+    int0:
+    int1:
+    tmx_bits:
+    tmx_freq:
+    pwm_sel:
+    pwm_freq:
+  misc2:
+    comp_edge:
+  misclvr:
+    lvr_4bit:
+    bandgap:
 ---
 
 # PMS152

--- a/chips/PMS154C.md
+++ b/chips/PMS154C.md
@@ -14,6 +14,16 @@ Comp: 1
 ADC: "-"
 Special: LCD
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_IO_DRV_LOW, FUSE_IO_DRV_NORMAL]
+    bootup:
+    lvr:
+  misc2:
+    comp_edge:
+  notes: |
+    This µC has additional undocumented code options configured in `MISC2`: <https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pms154c.h#L156-L158>
 ---
 
 # PMS154C

--- a/chips/PMS15A.md
+++ b/chips/PMS15A.md
@@ -15,6 +15,12 @@ ADC: "-"
 Special: "-"
 oss_status: "Supported"
 related_to: PMS150C
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_IO_DRV_LOW, FUSE_IO_DRV_NORMAL]
+    bootup:
+    lvr:
 ---
 
 # PMS15A
@@ -24,7 +30,7 @@ The PMS15A may just be a marketing name for the [PMS150C](/chips/PMS150C).
 So far, all PMS15A tested appear to be identical to the PMS150C and have the same ROM size.
 The ROM size restriction is only enforced when using the official IDE.
 **Of course we can't guarantee that Padauk doesn't change this in the future.**
--- 
+--
 *[Source 1](https://github.com/free-pdk/free-pdk.github.io/issues/21)*,
 *[Source 2](https://www.eevblog.com/forum/blog/eevblog-1144-padauk-programmer-reverse-engineering/msg2703550/?topicseen#msg2703550)*
 </div>

--- a/chips/PMS171B.md
+++ b/chips/PMS171B.md
@@ -14,6 +14,25 @@ Comp: 1
 ADC: 8-Bit
 Special: "-"
 oss_status: "Supported"
+code_options:
+  fuse:
+    security:
+    pin_drive: [FUSE_PB4_PB5_NORMAL, FUSE_PB4_PB5_STRONG]
+    bootup:
+  rom:
+    int0:
+    int1:
+    tmx_bits:
+    tmx_freq:
+    tm2_out:
+    pwm_sel:
+  misc2:
+    comp_edge:
+  misclvr:
+    lvr_4bit:
+    bandgap:
+  notes: |
+    Some additional options seem to exist which are not documented in the datasheet: <https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pms171b.h#L145-L148>
 ---
 
 # PMS171B

--- a/tutorial.md
+++ b/tutorial.md
@@ -35,15 +35,14 @@ Some code options are set as fuses, whereas others are set in undocumented regis
 To figure out whether a code option is set as a fuse or in an undocumented register, you can consult the following table.
 For µCs not listed in the table, you need to look into the PDK include files as described in the next two sections, or into the original `.INC` files that come with the Padauk IDE.
 
-Hovering over a table cell will provide you with the name of the defines representing the code option.
-
 {% include device_code_options.html %}
 
 ### Fuses
 
 Some of the code options are configured by setting bits in a magic word towards the end of the ROM.
-These can be set using the `PDK_SET_FUSE(...)` macro defined in `pdk/fuse.h`.
-The factory-default fuse settings differ depending on the µC model, which is why it is best to always set all fuses.
+These can be set using the `PDK_SET_FUSE(...)` macro.
+The factory-default fuse settings differ depending on the µC model, which is why it is best to always set all supported fuses.
+Be aware that your program must only contain a single call to `PDK_SET_FUSE`.
 
 ```c
 // Example of setting fuses on a PFS173

--- a/tutorial.md
+++ b/tutorial.md
@@ -76,8 +76,8 @@ Other code options are configured in undocumented registers:
   (`periph/misclvr.h` example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L180))
   (`periph/misclvr_basic.h` example: [pfs154.h](https://github.com/free-pdk/pdk-includes/blob/6417af6b35341b6436a48dbb2730f5ffe1f41e6f/device/pfs154.h#L148)).
 
-<div class="callout">
-    It is unclear whether you are allowed to change these code options while the µC is running, or whether you are supposed to only set them once and leave them as they are.
+<div class="callout" markdown="1">
+It is unclear whether you are allowed to change these code options while the µC is running, or whether you are supposed to only set them once and leave them as they are.
 </div>
 
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -37,7 +37,7 @@ To figure out whether a code option is set as a fuse or in an undocumented regis
 
 Some of the code options are configured by setting bits in a magic word towards the end of the ROM.
 These can be set using the `PDK_SET_FUSE(...)` macro defined in `pdk/fuse.h`.
-For a list of code options that are defined as fuses, take a look into `pdk/device/<your µC>.h` 
+For a list of code options that are defined as fuses, take a look into `pdk/device/<your µC>.h`
 (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L51-L56))
 and look for defines that start with `FUSE_`.
 The factory-default fuse settings differ depending on the µC model, which is why it is best to always set all fuses.
@@ -64,22 +64,22 @@ void main(void)
 
 Other code options are configured in undocumented registers:
 
-- `ROP`: Many µCs have a `ROP` register that configures 
+- `ROP`: Many µCs have a `ROP` register that configures
   [PWM, timer, and external interrupt related code options](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h#L41-L74).
-  To find out if your µC uses the `ROP` register, check if the 
+  To find out if your µC uses the `ROP` register, check if the
   [`periph/rop.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h)
   file is included at the bottom of `pdk/device/<your µC>.h`
   (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L181)).
-- `MISC2`: Some µCs have a `MISC2` register that supports 
+- `MISC2`: Some µCs have a `MISC2` register that supports
   [selecting the comparator edge(s) that trigger an interrupt](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h#L42-L44).
-  To find out if your µC uses the `MISC2` register, check if the 
+  To find out if your µC uses the `MISC2` register, check if the
   [`periph/misc2.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h)
   file is included at the bottom of `pdk/device/<your µC>.h`
   (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L179)).
 - `MISCLVR`: Some µCs configure the LVR and sometimes bandgap related code options in a `MISCLVR` register.
-  To find out if your µC uses the `MISCLVR` register, check if the 
+  To find out if your µC uses the `MISCLVR` register, check if the
   [`periph/misclvr.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misclvr.h)
-  or 
+  or
   [`periph/misclvr_basic.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misclvr_basic.h)
   file is included at the bottom of `pdk/device/<your µC>.h`
   (`periph/misclvr.h` example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L180))
@@ -87,6 +87,113 @@ Other code options are configured in undocumented registers:
 
 <div class="callout" markdown="1">
 It is unclear whether you are allowed to change these code options while the µC is running, or whether you are supposed to only set them once and leave them as they are.
+</div>
+
+### Overview
+
+<div class="table-responsive" style="font-size: 14px">
+  <table>
+    <thead>
+      <tr>
+        <th colspan="1" rowspan="3">µC</th>
+        <th colspan="4" rowspan="2">Fuse</th>
+        <th colspan="12">Undocumented Register</th>
+      </tr>
+      <tr>
+        <th colspan="7">ROP</th>
+        <th colspan="1">MISC2</th>
+        <th colspan="3">MISCLVR</th>
+      </tr>
+      <tr>
+        <th>Security</th>
+        <th>Drive Pins</th>
+        <th>Startup Speed</th>
+        <th>3-bit LVR</th>
+
+        <th>INT0 Source</th>
+        <th>INT1 Source</th>
+        <th>TMX Bits</th>
+        <th>TMX CLK</th>
+        <th>PWM Type</th>
+        <th>PWM CLK</th>
+        <th>TM2 OUT</th>
+
+        <th>COMP INT Edge</th>
+
+        <th>3-bit LVR</th>
+        <th>4-bit LVR</th>
+        <th>Bandgap CLK</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>PFS173</strong></td>
+
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td></td>
+
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td></td>
+
+        <td>x</td>
+
+        <td></td>
+        <td>x</td>
+        <td>x</td>
+      </tr>
+      <tr>
+        <td><strong>PMS150C</strong></td>
+
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+
+        <td></td>
+
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><strong>PFS154</strong></td>
+
+        <td>x</td>
+        <td>x</td>
+        <td>x</td>
+        <td></td>
+
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+
+        <td>x</td>
+
+        <td>x</td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -64,15 +64,24 @@ void main(void)
 
 Other code options are configured in undocumented registers:
 
-- `ROP`: Many µCs have a `ROP` register that configures [PWM, timer, and external interrupt related code options](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h#L41-L74).
-  To find out if your µC uses the `ROP` register, check if the `periph/rop.h` file is included at the bottom of `pdk/device/<your µC>.h`
+- `ROP`: Many µCs have a `ROP` register that configures 
+  [PWM, timer, and external interrupt related code options](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h#L41-L74).
+  To find out if your µC uses the `ROP` register, check if the 
+  [`periph/rop.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h)
+  file is included at the bottom of `pdk/device/<your µC>.h`
   (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L181)).
 - `MISC2`: Some µCs have a `MISC2` register that supports 
   [selecting the comparator edge(s) that trigger an interrupt](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h#L42-L44).
-  To find out if your µC uses the `MISC2` register, check if the `periph/misc2.h` file is included at the bottom of `pdk/device/<your µC>.h`
+  To find out if your µC uses the `MISC2` register, check if the 
+  [`periph/misc2.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h)
+  file is included at the bottom of `pdk/device/<your µC>.h`
   (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L179)).
 - `MISCLVR`: Some µCs configure the LVR and sometimes bandgap related code options in a `MISCLVR` register.
-  To find out if your µC uses the `MISCLVR` register, check if the `periph/misclvr.h` or `periph/misclvr_basic.h` file is included at the bottom of `pdk/device/<your µC>.h`
+  To find out if your µC uses the `MISCLVR` register, check if the 
+  [`periph/misclvr.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misclvr.h)
+  or 
+  [`periph/misclvr_basic.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misclvr_basic.h)
+  file is included at the bottom of `pdk/device/<your µC>.h`
   (`periph/misclvr.h` example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L180))
   (`periph/misclvr_basic.h` example: [pfs154.h](https://github.com/free-pdk/pdk-includes/blob/6417af6b35341b6436a48dbb2730f5ffe1f41e6f/device/pfs154.h#L148)).
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -25,6 +25,81 @@ You have to initialize all registers yourself.
   _sdcc_external_startup, IHRC, ILRC, external crystal, SYSCLK, maximum possible clk frequency, factory calibrated values, easy pdk calibration, ...
 </div>
 
+## Code Options
+
+Padauk µCs have several options that are called "code option" in the datasheet.
+There is usually an overview of all code options a µC supports in a chapter towards the end of the datasheet.
+The datasheet does not provide any detailed information on how to set the code options, because Padauk expects users to use their IDE which takes care of that for you.
+
+To figure out whether a code option is set as a fuse or in an undocumented register, you need to look into the PDK include files as described in the next two sections, or into the original `.INC` files that come with the Padauk IDE.
+
+### Fuses
+
+Some of the code options are configured by setting bits in a magic word towards the end of the ROM.
+These can be set using the `PDK_SET_FUSE(...)` macro defined in `pdk/fuse.h`.
+For a list of code options that are defined as fuses, take a look into `pdk/device/<your µC>.h` 
+(example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L51-L56))
+and look for defines that start with `FUSE_`.
+The factory-default fuse settings differ depending on the µC model, which is why it is best to always set all fuses.
+
+```c
+// Example of setting fuses on a PFS173
+// The available fuses vary depending on the µC model!
+#define PFS173
+
+#include <pdk/device.h>
+
+unsigned char _sdcc_external_startup(void)
+{
+    PDK_SET_FUSE(FUSE_SECURITY_ON | FUSE_PB4_PB5_NORMAL | FUSE_BOOTUP_SLOW);
+}
+
+void main(void)
+{
+    // ...
+}
+```
+
+### Undocumented Registers
+
+Other code options are configured in undocumented registers:
+
+- `ROP`: Many µCs have a `ROP` register that configures [PWM, timer, and external interrupt related code options](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h#L41-L74).
+  To find out if your µC uses the `ROP` register, check if the `periph/rop.h` file is included at the bottom of `pdk/device/<your µC>.h`
+  (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L181)).
+- `MISC2`: Some µCs have a `MISC2` register that supports 
+  [selecting the comparator edge(s) that trigger an interrupt](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h#L42-L44).
+  To find out if your µC uses the `MISC2` register, check if the `periph/misc2.h` file is included at the bottom of `pdk/device/<your µC>.h`
+  (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L179)).
+- `MISCLVR`: Some µCs configure the LVR and sometimes bandgap related code options in a `MISCLVR` register.
+  To find out if your µC uses the `MISCLVR` register, check if the `periph/misclvr.h` or `periph/misclvr_basic.h` file is included at the bottom of `pdk/device/<your µC>.h`
+  (`periph/misclvr.h` example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L180))
+  (`periph/misclvr_basic.h` example: [pfs154.h](https://github.com/free-pdk/pdk-includes/blob/6417af6b35341b6436a48dbb2730f5ffe1f41e6f/device/pfs154.h#L148)).
+
+<div class="callout">
+    It is unclear whether you are allowed to change these code options while the µC is running, or whether you are supposed to only set them once and leave them as they are.
+</div>
+
+
+```c
+// Example of using the ROP register on a PFS173
+// The available settings and undocumented registers vary depending on the µC model!
+#define PFS173
+
+#include <pdk/device.h>
+
+unsigned char _sdcc_external_startup(void)
+{
+    // ...
+}
+
+void main(void)
+{
+    // Use PA4 for INT1 instead of PB0
+    ROP = ROP_INT_SRC_PA4;
+}
+```
+
 ## Digital I/O
 
 Digital I/O is organized in ports of (at most) 8 pins. The ports are named `A`, `B`, and `C`.

--- a/tutorial.md
+++ b/tutorial.md
@@ -35,7 +35,8 @@ Some code options are set as fuses, whereas others are set in undocumented regis
 To figure out whether a code option is set as a fuse or in an undocumented register, you can consult the following table.
 For µCs not listed in the table, you need to look into the PDK include files as described in the next two sections, or into the original `.INC` files that come with the Padauk IDE.
 
-Hovering over a table cell will provide you with the name of define representing the code option.
+Hovering over a table cell will provide you with the name of the defines representing the code option.
+
 {% include device_code_options.html %}
 
 ### Fuses

--- a/tutorial.md
+++ b/tutorial.md
@@ -30,16 +30,18 @@ You have to initialize all registers yourself.
 Padauk µCs have several options that are called "code option" in the datasheet.
 There is usually an overview of all code options a µC supports in a chapter towards the end of the datasheet.
 The datasheet does not provide any detailed information on how to set the code options, because Padauk expects users to use their IDE which takes care of that for you.
+Some code options are set as fuses, whereas others are set in undocumented registers.
 
-To figure out whether a code option is set as a fuse or in an undocumented register, you need to look into the PDK include files as described in the next two sections, or into the original `.INC` files that come with the Padauk IDE.
+To figure out whether a code option is set as a fuse or in an undocumented register, you can consult the following table.
+For µCs not listed in the table, you need to look into the PDK include files as described in the next two sections, or into the original `.INC` files that come with the Padauk IDE.
+
+Hovering over a table cell will provide you with the name of define representing the code option.
+{% include device_code_options.html %}
 
 ### Fuses
 
 Some of the code options are configured by setting bits in a magic word towards the end of the ROM.
 These can be set using the `PDK_SET_FUSE(...)` macro defined in `pdk/fuse.h`.
-For a list of code options that are defined as fuses, take a look into `pdk/device/<your µC>.h`
-(example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L51-L56))
-and look for defines that start with `FUSE_`.
 The factory-default fuse settings differ depending on the µC model, which is why it is best to always set all fuses.
 
 ```c
@@ -66,136 +68,13 @@ Other code options are configured in undocumented registers:
 
 - `ROP`: Many µCs have a `ROP` register that configures
   [PWM, timer, and external interrupt related code options](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h#L41-L74).
-  To find out if your µC uses the `ROP` register, check if the
-  [`periph/rop.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/rop.h)
-  file is included at the bottom of `pdk/device/<your µC>.h`
-  (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L181)).
 - `MISC2`: Some µCs have a `MISC2` register that supports
   [selecting the comparator edge(s) that trigger an interrupt](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h#L42-L44).
-  To find out if your µC uses the `MISC2` register, check if the
-  [`periph/misc2.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misc2.h)
-  file is included at the bottom of `pdk/device/<your µC>.h`
-  (example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L179)).
 - `MISCLVR`: Some µCs configure the LVR and sometimes bandgap related code options in a `MISCLVR` register.
-  To find out if your µC uses the `MISCLVR` register, check if the
-  [`periph/misclvr.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misclvr.h)
-  or
-  [`periph/misclvr_basic.h`](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/periph/misclvr_basic.h)
-  file is included at the bottom of `pdk/device/<your µC>.h`
-  (`periph/misclvr.h` example: [pfs173.h](https://github.com/free-pdk/pdk-includes/blob/f44fc2e7678b1ab72ed8bac6b9d408118f330ad8/device/pfs173.h#L180))
-  (`periph/misclvr_basic.h` example: [pfs154.h](https://github.com/free-pdk/pdk-includes/blob/6417af6b35341b6436a48dbb2730f5ffe1f41e6f/device/pfs154.h#L148)).
 
 <div class="callout" markdown="1">
 It is unclear whether you are allowed to change these code options while the µC is running, or whether you are supposed to only set them once and leave them as they are.
 </div>
-
-### Overview
-
-<div class="table-responsive" style="font-size: 14px">
-  <table>
-    <thead>
-      <tr>
-        <th colspan="1" rowspan="3">µC</th>
-        <th colspan="4" rowspan="2">Fuse</th>
-        <th colspan="12">Undocumented Register</th>
-      </tr>
-      <tr>
-        <th colspan="7">ROP</th>
-        <th colspan="1">MISC2</th>
-        <th colspan="3">MISCLVR</th>
-      </tr>
-      <tr>
-        <th>Security</th>
-        <th>Drive Pins</th>
-        <th>Startup Speed</th>
-        <th>3-bit LVR</th>
-
-        <th>INT0 Source</th>
-        <th>INT1 Source</th>
-        <th>TMX Bits</th>
-        <th>TMX CLK</th>
-        <th>PWM Type</th>
-        <th>PWM CLK</th>
-        <th>TM2 OUT</th>
-
-        <th>COMP INT Edge</th>
-
-        <th>3-bit LVR</th>
-        <th>4-bit LVR</th>
-        <th>Bandgap CLK</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><strong>PFS173</strong></td>
-
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td></td>
-
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td></td>
-
-        <td>x</td>
-
-        <td></td>
-        <td>x</td>
-        <td>x</td>
-      </tr>
-      <tr>
-        <td><strong>PMS150C</strong></td>
-
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-
-        <td></td>
-
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td><strong>PFS154</strong></td>
-
-        <td>x</td>
-        <td>x</td>
-        <td>x</td>
-        <td></td>
-
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-
-        <td>x</td>
-
-        <td>x</td>
-        <td></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
 
 ```c
 // Example of using the ROP register on a PFS173


### PR DESCRIPTION
We could also create a big table that lists all available options on a µC-basis and whether they are configured as a fuse or in an undocumented register. What do you think?