### PR TITLE
Detect proprietary toolchain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,8 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bundle exec jekyll build --trace
+        with:
+          GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Jekyll is a static site generator that takes markdown files and transforms them 
 To run Jekyll locally, install `ruby` `>=2.5.0` and the `bundler` gem (`gem install bundler`).
 Then install dependencies by running `bundle install` and build the site by calling `bundle exec jekyll serve --livereload`.
 
+We use the GitHub API to fetch a list of projects using Padauk µCs and the latest activity in the `free-pdk` organization.
+The API has a rate limit of 60 requests per hour for unauthenticated requests, which may not be sufficient for the amount of API requests we make when building the website.
+Please set a `GITHUB_TOKEN` environment variable with a personal access token [you can create here (no scopes necessary)](https://github.com/settings/tokens).
+If you don't set a `GITHUB_TOKEN` environment variable, we automatically make less requests to the API, but some features like detecting projects using Padauk's proprietary toolchain will be skipped.
+
 ## Deployment
 
 Every commit on the `production` branch is built and deployed by a [GitHub Action](https://github.com/free-pdk/free-pdk.github.io/actions) and the result is force-pushed to the `master` branch, which is deployed to https://free-pdk.github.io by GitHub Pages.

--- a/_includes/community_projects.html
+++ b/_includes/community_projects.html
@@ -8,24 +8,22 @@
       <br />
       <strong>{{ repo.name | escape }}</strong>
     </h4>
+    {% if project.type == 'free-pdk' %}
+      <div class="badges">
+        <span class="green">Uses open source toolchain</span>
+      </div>
+    {% elsif project.type == 'proprietary' %}
+      <div class="badges">
+        <span class="orange">Uses proprietary toolchain</span>
+      </div>
+    {% endif %}
     <p>
       {{ repo.description | escape }}
     </p>
     <div class="spacer"></div>
-    {% if project.type == 'proprietary' %}
-      <p class="callout">
-        :warning:
-        <span>Uses the proprietary toolchain</span>
-      </p>
-    {% elsif project.type == 'free-pdk' %}
-      <p class="callout success">
-        :tada:
-        <span>Uses the Free PDK toolchain</span>
-      </p>
-    {% endif %}
     <div class="meta">
       {% assign topics = repo.topics | where_exp:"topic","topic != 'padauk' and topic != 'pdk' and topic != 'free-pdk'" %}
-      {% if topics %}
+      {% if topics != empty %}
         {% for topic in topics %}
           <code>{{ topic }}</code>
         {% endfor %}

--- a/_includes/community_projects.html
+++ b/_includes/community_projects.html
@@ -10,11 +10,11 @@
     </h4>
     {% if project.type == 'free-pdk' %}
       <div class="badges">
-        <span class="green">Uses open source toolchain</span>
+        <span class="badge green">Uses Free PDK toolchain</span>
       </div>
     {% elsif project.type == 'proprietary' %}
       <div class="badges">
-        <span class="orange">Uses proprietary toolchain</span>
+        <span class="badge orange">Uses proprietary toolchain</span>
       </div>
     {% endif %}
     <p>

--- a/_includes/community_projects.html
+++ b/_includes/community_projects.html
@@ -11,15 +11,20 @@
     <p>
       {{ repo.description | escape }}
     </p>
+    <div class="spacer"></div>
     {% if project.type == 'proprietary' %}
       <p class="callout">
         :warning:
-        <span>This project appears to use Padauk's proprietary toolchain.</span>
+        <span>Uses the proprietary toolchain</span>
+      </p>
+    {% elsif project.type == 'free-pdk' %}
+      <p class="callout success">
+        :tada:
+        <span>Uses the Free PDK toolchain</span>
       </p>
     {% endif %}
-    <div class="spacer"></div>
     <div class="meta">
-      {% assign topics = repo.topics | where_exp:"topic","topic != 'padauk' and topic != 'pdk'" %}
+      {% assign topics = repo.topics | where_exp:"topic","topic != 'padauk' and topic != 'pdk' and topic != 'free-pdk'" %}
       {% if topics %}
         {% for topic in topics %}
           <code>{{ topic }}</code>

--- a/_includes/community_projects.html
+++ b/_includes/community_projects.html
@@ -1,27 +1,34 @@
 <div markdown="0" class="community-projects">
 {% for project in site.projects_using_padauk %}
+{% assign repo = project.data %}
 <div>
-  <a class="card" href="{{ project.html_url }}">
+  <a class="card" href="{{ repo.html_url }}">
     <h4>
-      <span class="owner">{{ project.owner.login | escape }}</span>
+      <span class="owner">{{ repo.owner.login | escape }}</span>
       <br />
-      <strong>{{ project.name | escape }}</strong>
+      <strong>{{ repo.name | escape }}</strong>
     </h4>
     <p>
-      {{ project.description | escape }}
+      {{ repo.description | escape }}
     </p>
+    {% if project.type == 'proprietary' %}
+      <p class="callout">
+        :warning:
+        <span>This project appears to use Padauk's proprietary toolchain.</span>
+      </p>
+    {% endif %}
     <div class="spacer"></div>
     <div class="meta">
-      {% assign topics = project.topics | where_exp:"topic","topic != 'padauk' and topic != 'pdk'" %}
+      {% assign topics = repo.topics | where_exp:"topic","topic != 'padauk' and topic != 'pdk'" %}
       {% if topics %}
         {% for topic in topics %}
           <code>{{ topic }}</code>
         {% endfor %}
         <br />
       {% endif %}
-      updated {{ project.pushed_at | timeago }}
-      {% if project.stargazers_count > 0 %}
-        · {{ project.stargazers_count }} :star:
+      updated {{ repo.pushed_at | timeago }}
+      {% if repo.stargazers_count > 0 %}
+        · {{ repo.stargazers_count }} :star:
       {% endif %}
     </div>
   </a>

--- a/_plugins/find_github_projects_using_padauk.rb
+++ b/_plugins/find_github_projects_using_padauk.rb
@@ -62,9 +62,9 @@ module GitHubPadaukTopics
 
         projects = Parallel.map(repos, in_threads: 10) do |repo|
           type = "unknown"
+          # Only fetch repository files if we have an access token, because we run into rate limits otherwise.
           if access_token then
-            # Only fetch repository files if we have an access token, because we run into rate limits otherwise.
-            if repo["topics"].include?("free-pdk") then
+            if repo["topics"].include?('free-pdk') or repo["topics"].include?('sdcc') or repo["description"].match(/free.?pdk/i) or repo["description"].match(/sdcc/i) then
               type = "free-pdk"
             else
               Jekyll.logger.info "Listing files of #{repo["full_name"]}"
@@ -79,8 +79,7 @@ module GitHubPadaukTopics
                 result = client.readme(repo["full_name"], :ref => repo["default_branch"], :accept => 'application/vnd.github.VERSION.raw')
                 log_rate_limit(client)
 
-                has_free_pdk = result.include?('free-pdk')
-                if has_free_pdk
+                if result.match(/free.?pdk/i) or result.match(/sdcc/i)
                   type = "free-pdk"
                 end
               end

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -8,9 +8,9 @@ $content-width: 1040px;
 @import "minima";
 
 // custom variables
-$radius: 0.5em;
-$card-margin: 1em;
-$card-padding: 1em;
+$radius: 8px;
+$card-margin: 16px;
+$card-padding: 16px;
 $border: 1px solid #ececec;
 
 $callout-color: #FFC04C;
@@ -84,28 +84,6 @@ table {
   hr {
     border: $border;
   }
-
-  .callout {
-    background-color: lighten($callout-color, 25%);
-
-    &.success {
-      background-color: lighten(#adff00, 25%);
-    }
-
-    margin-left: -$card-padding;
-    margin-right: -$card-padding;
-    padding-left: $spacing-unit / 2;
-    padding-right: $spacing-unit / 2;
-    padding-top: $card-padding / 2;
-    padding-bottom: $card-padding / 2;
-
-    display: flex;
-    align-items: center;
-
-    .emoji {
-      margin-right: $spacing-unit / 2;
-    }
-  }
 }
 
 a.card {
@@ -153,6 +131,27 @@ a.card {
 
     .spacer {
       flex-grow: 1;
+    }
+
+    .badges {
+      margin-top: -$spacing-unit / 2;
+      margin-bottom: $spacing-unit / 2;
+
+      span {
+        font-size: $small-font-size;
+        padding: 4px 8px;
+        border-radius: 6px;
+
+        &.green {
+          color: #155724;
+          background-color: lighten(#d4edda, 5%);
+        }
+
+        &.orange {
+          color: #856404;
+          background-color: #fff3cd;
+        }
+      }
     }
 
     .owner {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -98,6 +98,23 @@ a.card {
   }
 }
 
+.badge {
+  font-size: $small-font-size;
+  padding: 4px 8px;
+  border-radius: 6px;
+  white-space: nowrap;
+
+  &.green {
+    color: #155724;
+    background-color: lighten(#d4edda, 5%);
+  }
+
+  &.orange {
+    color: #856404;
+    background-color: #fff3cd;
+  }
+}
+
 .community-projects {
   display: flex;
   flex: 0 1 auto;
@@ -137,22 +154,8 @@ a.card {
       margin-top: -$spacing-unit / 2;
       margin-bottom: $spacing-unit / 2;
 
-      span {
-        font-size: $small-font-size;
-        padding: 4px 8px;
-        border-radius: 6px;
-
-        &.green {
-          color: #155724;
-          background-color: lighten(#d4edda, 5%);
-        }
-
-        &.orange {
-          color: #856404;
-          background-color: #fff3cd;
-        }
-      }
     }
+
 
     .owner {
       font-size: $small-font-size;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -13,6 +13,8 @@ $card-margin: 1em;
 $card-padding: 1em;
 $border: 1px solid #ececec;
 
+$callout-color: #FFC04C;
+
 #pinout-diagram {
   margin: 0 $spacing-unit;
 
@@ -81,6 +83,22 @@ table {
 
   hr {
     border: $border;
+  }
+
+  .callout {
+    background-color: lighten($callout-color, 25%);
+    margin-left: -$card-padding;
+    margin-right: -$card-padding;
+    padding-left: $spacing-unit / 2;
+    padding-right: $spacing-unit / 2;
+    padding-top: $card-padding / 2;
+    padding-bottom: $card-padding / 2;
+    display: flex;
+    align-items: center;
+
+    .emoji {
+      margin-right: $spacing-unit / 2;
+    }
   }
 }
 
@@ -188,8 +206,6 @@ a.card {
     margin: 0;
   }
 }
-
-$callout-color: #FFC04C;
 
 div.callout {
   @extend .card;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -87,12 +87,18 @@ table {
 
   .callout {
     background-color: lighten($callout-color, 25%);
+
+    &.success {
+      background-color: lighten(#adff00, 25%);
+    }
+
     margin-left: -$card-padding;
     margin-right: -$card-padding;
     padding-left: $spacing-unit / 2;
     padding-right: $spacing-unit / 2;
     padding-top: $card-padding / 2;
     padding-bottom: $card-padding / 2;
+
     display: flex;
     align-items: center;
 

--- a/index.md
+++ b/index.md
@@ -101,8 +101,10 @@ More information, including information on the programming sequence, can be foun
 
 These projects are auto-populated once per day by
 [searching GitHub for repositories with the `padauk` topic]({{ site.projects_using_padauk_query_url }}).
-Projects that additionally have the `free-pdk`/`sdcc` topic or mention `free-pdk`/`sdcc` in their description or README are highlighted as "uses open source toolchain".
-Projects that contain `.PRE` files are marked as "uses proprietary toolchain".
+Projects that additionally have the `free-pdk` topic are highlighted as
+<span class="badge green">Uses Free PDK toolchain</span>.
+Projects that contain `.PRE` files are marked as
+<span class="badge orange">Uses proprietary toolchain</span>.
 
 {% include community_projects.html %}
 

--- a/index.md
+++ b/index.md
@@ -100,7 +100,9 @@ More information, including information on the programming sequence, can be foun
 ## Projects from the Community
 
 These projects are auto-populated once per day by
-[searching GitHub for repositories with the `padauk` tag]({{ site.projects_using_padauk_query_url }}).
+[searching GitHub for repositories with the `padauk` topic]({{ site.projects_using_padauk_query_url }}).
+Projects that additionally have the `free-pdk`/`sdcc` topic or mention `free-pdk`/`sdcc` in their description or README are highlighted as "uses open source toolchain".
+Projects that contain `.PRE` files are marked as "uses proprietary toolchain".
 
 {% include community_projects.html %}
 


### PR DESCRIPTION
This PR fixes #39 by adding a warning to projects using Padauk's proprietary IDE.
As described in the updated README, the additional API request we need to make per project quickly runs into the rate limit of the GitHub API. You can set a `GITHUB_TOKEN` environment variable to increase the rate limit when building the docs locally.
Since we don't set a `GITHUB_TOKEN` variable on netlify, the preview for this PR will _not_ detect the proprietary toolchain.
![image](https://user-images.githubusercontent.com/2145092/87847423-6b7bfb80-c8d8-11ea-9cd4-433b13bec255.png)
