### PR TITLE
Update deploy.yml to newer Ubuntu LTS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   github-pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Upgrade to next LTS ubuntu version as 20.04 is not supported anymore. 22.04 is supported unit 2027 and may have to be upgraded then.